### PR TITLE
client: fix about.xml, loadfolder.xml not filtered out

### DIFF
--- a/vsc-extension/src/resources/dependencyResourceProvider.ts
+++ b/vsc-extension/src/resources/dependencyResourceProvider.ts
@@ -30,7 +30,7 @@ export class DependencyResourceProvider implements Provider {
       caseSensitiveMatch: false,
       cwd: root,
       absolute: true,
-      ignore: ['about.xml', 'loadfolder.xml'],
+      ignore: ['**/about.xml', '**/loadfolder.xml'],
       onlyFiles: true,
     })
 


### PR DESCRIPTION
fix https://github.com/zzzz465/rwxml-language-server/pull/64 doesn't filter `loadfolder.xml`, `about.xml` correctly 