### PR TITLE
feature: cache dll extracted data

### DIFF
--- a/language-server/src/fileStore.ts
+++ b/language-server/src/fileStore.ts
@@ -19,9 +19,9 @@ export class FileStore {
   constructor(notiEventManager: NotificationEventManager, @inject(LogToken) baseLogger: winston.Logger) {
     this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
 
-    notiEventManager.event.on('fileAdded', this.onFileAdded.bind(this))
-    notiEventManager.event.on('fileChanged', this.onFileChanged.bind(this))
-    notiEventManager.event.on('fileDeleted', this.onFileDeleted.bind(this))
+    notiEventManager.preEvent.on('fileAdded', this.onFileAdded.bind(this))
+    notiEventManager.preEvent.on('fileChanged', this.onFileChanged.bind(this))
+    notiEventManager.preEvent.on('fileDeleted', this.onFileDeleted.bind(this))
   }
 
   get(uri: string) {

--- a/language-server/src/resourceStore.ts
+++ b/language-server/src/resourceStore.ts
@@ -251,7 +251,9 @@ export class ResourceStore {
   private isProjectResource(fileOrUri: File | string): boolean {
     const uri = fileOrUri instanceof File ? fileOrUri.uri.toString() : fileOrUri
 
-    const file = this.fileStore.get(uri)
+    // 1. (add/change) does this exists?
+    // 2. (deleted file) does this already registered as project resource?
+    const file = this.fileStore.get(uri) ?? this.files.get(uri)
     if (!file) {
       return false
     }

--- a/publish/master/package.json
+++ b/publish/master/package.json
@@ -56,6 +56,10 @@
       {
         "command": "rwxml:debug:printXMLDocumentObject",
         "title": "RWXML: (debug) print current document's XMLDocument"
+      },
+      {
+        "command": "rwxml:cache:clear",
+        "title": "RWXML: Clear DLL Cache"
       }
     ],
     "configuration": [

--- a/publish/master/package.json
+++ b/publish/master/package.json
@@ -60,6 +60,10 @@
       {
         "command": "rwxml:cache:clear",
         "title": "RWXML: Clear DLL Cache"
+      },
+      {
+        "command": "rwxml:cache:openDir",
+        "title": "RWXML: Open Cache Directory"
       }
     ],
     "configuration": [

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -38,7 +38,6 @@
               "set log level. warning: this might affect performance."
             ]
           },
-
           "rwxml.paths.rimWorld": {
             "type": "string",
             "scope": "machine-overridable",
@@ -128,6 +127,7 @@
     "axios": "^0.21.1",
     "cache-decorator": "^0.1.6",
     "cheerio": "^1.0.0-rc.10",
+    "dayjs": "^1.10.7",
     "double-ended-queue": "^2.1.0-0",
     "fast-glob": "^3.2.7",
     "htmlparser2": "^7.0.0",

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -12,6 +12,10 @@
       {
         "command": "rwxml:debug:printXMLDocumentObject",
         "title": "RWXML: (debug) print current document's XMLDocument"
+      },
+      {
+        "command": "rwxml:cache:clear",
+        "title": "RWXML: Clear DLL Cache"
       }
     ],
     "configuration": [

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -16,6 +16,10 @@
       {
         "command": "rwxml:cache:clear",
         "title": "RWXML: Clear DLL Cache"
+      },
+      {
+        "command": "rwxml:cache:openDir",
+        "title": "RWXML: Open Cache Directory"
       }
     ],
     "configuration": [

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -105,6 +105,7 @@
     "@types/lodash": "^4.14.159",
     "@types/normalize-path": "^3.0.0",
     "@types/semver": "^7.3.8",
+    "@types/uuid": "^8.3.4",
     "@types/vscode": "^1.59.0",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
@@ -140,6 +141,7 @@
     "tsconfig-paths": "^3.9.0",
     "tsyringe": "^4.6.0",
     "typescript-collections": "^1.3.3",
+    "uuid": "^8.3.2",
     "vscode-languageclient": "^6.1.3",
     "xpath": "^0.0.32"
   }

--- a/vsc-extension/pnpm-lock.yaml
+++ b/vsc-extension/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@types/lodash': ^4.14.159
   '@types/normalize-path': ^3.0.0
   '@types/semver': ^7.3.8
+  '@types/uuid': ^8.3.4
   '@types/vscode': ^1.59.0
   '@typescript-eslint/eslint-plugin': ^4.31.1
   '@typescript-eslint/parser': ^4.31.1
@@ -37,6 +38,7 @@ specifiers:
   tsyringe: ^4.6.0
   typescript: ^4.3.5
   typescript-collections: ^1.3.3
+  uuid: ^8.3.2
   vscode-languageclient: ^6.1.3
   vscode-uri: ^3.0.2
   webpack: ^5.11.0
@@ -60,6 +62,7 @@ dependencies:
   tsconfig-paths: 3.11.0
   tsyringe: 4.6.0
   typescript-collections: 1.3.3
+  uuid: 8.3.2
   vscode-languageclient: 6.1.4
   xpath: 0.0.32
 
@@ -70,6 +73,7 @@ devDependencies:
   '@types/lodash': 4.14.172
   '@types/normalize-path': 3.0.0
   '@types/semver': 7.3.8
+  '@types/uuid': 8.3.4
   '@types/vscode': 1.60.0
   '@typescript-eslint/eslint-plugin': 4.31.1_e2d3c88d378335c4183365c112128ce9
   '@typescript-eslint/parser': 4.31.1_eslint@7.32.0+typescript@4.4.3
@@ -857,6 +861,10 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/uuid/8.3.4:
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
     dev: true
 
   /@types/vscode/1.60.0:
@@ -4861,8 +4869,6 @@ packages:
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-    dev: true
-    optional: true
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}

--- a/vsc-extension/pnpm-lock.yaml
+++ b/vsc-extension/pnpm-lock.yaml
@@ -13,6 +13,7 @@ specifiers:
   axios: ^0.21.1
   cache-decorator: ^0.1.6
   cheerio: ^1.0.0-rc.10
+  dayjs: ^1.10.7
   double-ended-queue: ^2.1.0-0
   eslint: ^7.32.0
   eslint-config-prettier: ^8.3.0
@@ -46,6 +47,7 @@ dependencies:
   axios: 0.21.4
   cache-decorator: 0.1.6
   cheerio: 1.0.0-rc.10
+  dayjs: 1.10.7
   double-ended-queue: 2.1.0-0
   fast-glob: 3.2.7
   htmlparser2: 7.1.2
@@ -1751,6 +1753,10 @@ packages:
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
     dev: true
+
+  /dayjs/1.10.7:
+    resolution: {integrity: sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==}
+    dev: false
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}

--- a/vsc-extension/src/mod/pathStore.ts
+++ b/vsc-extension/src/mod/pathStore.ts
@@ -1,4 +1,4 @@
-import _, { values } from 'lodash'
+import _ from 'lodash'
 import * as tsyringe from 'tsyringe'
 import * as vscode from 'vscode'
 import * as path from 'path'

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -6,6 +6,7 @@ import { Provider } from './provider'
 import { PathStore } from './pathStore'
 import * as crypto from 'crypto'
 import * as fs from 'fs/promises'
+import { mkdirSync } from 'fs'
 import * as path from 'path'
 import { md5sum } from '../utils/hash'
 import _ from 'lodash'
@@ -25,10 +26,16 @@ interface Cache {
 
 @injectable()
 export class CachedTypeInfoProvider implements Provider {
+  get dllCacheDirectory(): string {
+    return path.join(this.pathStore.cacheDirectory, 'dlls')
+  }
+
   constructor(
     private readonly typeInfoProvider: TypeInfoProvider,
     @inject(PathStore.token) private readonly pathStore: PathStore
-  ) {}
+  ) {
+    mkdirSync(this.dllCacheDirectory, { recursive: true })
+  }
 
   async listen(client: LanguageClient): Promise<void> {
     await client.onReady()

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -3,17 +3,126 @@ import { LanguageClient } from 'vscode-languageclient'
 import { TypeInfoProvider } from './typeInfoProvider'
 import { TypeInfoRequest, TypeInfoRequestResponse } from '../events'
 import { Provider } from './provider'
+import { PathStore } from './pathStore'
+import * as crypto from 'crypto'
+import * as vscode from 'vscode'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import { md5sum } from '../utils/hash'
+import _ from 'lodash'
+import dayjs from 'dayjs'
+
+interface Cache {
+  createdBy: string
+  createdAt: string // iso8601 format datetime
+
+  requestedFileUris: string[]
+  checksums: string[] // length is equal to rqeustedFileUris field
+
+  data: any
+}
 
 @injectable()
 export class CachedTypeInfoProvider implements Provider {
-  constructor(private readonly typeInfoProvider: TypeInfoProvider) {}
+  constructor(private readonly typeInfoProvider: TypeInfoProvider, private readonly pathStore: PathStore) {}
 
   async listen(client: LanguageClient): Promise<void> {
     await client.onReady()
     client.onRequest(TypeInfoRequest, this.onTypeInfoRequest.bind(this))
   }
 
+  /**
+   * @todo check cache confliction on write
+   */
   private async onTypeInfoRequest({ uris }: TypeInfoRequest): Promise<TypeInfoRequestResponse> {
-    throw new Error('method not implemented.')
+    // get cache name based on checksum name of given uris
+    // and make a short hash
+    const cacheName = this.getCacheName(uris).slice(0, 12)
+    const cachePath = path.join(this.pathStore.cacheDirectory, 'dlls', cacheName)
+
+    const checkCacheValid = async () => {
+      // https://nodejs.org/api/fs.html#file-system-flags
+      let file: fs.FileHandle | null = null
+
+      try {
+        file = await fs.open(cachePath, '644', 'a+')
+
+        const cache = await this.getCache(file)
+        return {
+          valid: this.isCacheValid(cache, uris),
+          data: cache.data,
+        }
+      } catch (e) {
+        console.error(e)
+      } finally {
+        await file?.close()
+      }
+
+      return {
+        valid: false,
+        data: null,
+      }
+    }
+
+    const cacheData = await checkCacheValid()
+    let data = cacheData.data
+    if (!cacheData.valid) {
+      const res = await this.typeInfoProvider.onTypeInfoRequest({ uris })
+      if (res.error) {
+        return res
+      }
+
+      data = res.data
+
+      await this.updateCache(cachePath, uris, data)
+    }
+
+    return data
+  }
+
+  private getCacheName(files: string[]): string {
+    const hash = crypto.createHash('md5')
+
+    for (const file of files) {
+      hash.update(file)
+    }
+
+    return hash.digest().toString('utf-8')
+  }
+
+  private async getCache(file: fs.FileHandle): Promise<Cache> {
+    const data = (await file.readFile()).toString('utf-8')
+    return JSON.parse(data) as Cache
+  }
+
+  private async isCacheValid(cache: Cache, files: string[]): Promise<boolean> {
+    const checksums = await this.getChecksums(files)
+
+    return _.isEqual(cache.checksums, checksums)
+  }
+
+  private async getChecksums(files: string[]): Promise<string[]> {
+    return [
+      ...files
+        .sort()
+        .map(md5sum)
+        .map((buff) => buff.toString('utf-8')),
+    ]
+  }
+
+  private async updateCache(cachePath: string, files: string[], data: any) {
+    const checksums = await this.getChecksums(files)
+
+    const cache: Cache = {
+      checksums,
+      createdAt: dayjs().format(),
+      createdBy: CachedTypeInfoProvider.name,
+      data,
+      requestedFileUris: files,
+    }
+
+    const raw = JSON.stringify(cache, null, 4)
+
+    await fs.writeFile(cachePath, raw, { encoding: 'utf-8', mode: 'w+' })
   }
 }

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -71,7 +71,7 @@ export class CachedTypeInfoProvider implements Provider {
           data: cache.data,
         }
       } catch (e) {
-        console.error(`[${requestId}] failed opening cache file: `, e)
+        console.error(`[${requestId}] failed opening cache. file: ${cachePath}, err: `, e)
       } finally {
         await file?.close()
       }
@@ -93,9 +93,11 @@ export class CachedTypeInfoProvider implements Provider {
       data = res.data
 
       await this.updateCache(cachePath, uris, data, requestId)
+    } else {
+      console.log(`cache hit! uris: ${JSON.stringify(uris, null, 4)}`)
     }
 
-    return data
+    return { data }
   }
 
   private getCacheName(files: string[]): string {

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -1,0 +1,19 @@
+import { injectable } from 'tsyringe'
+import { LanguageClient } from 'vscode-languageclient'
+import { TypeInfoProvider } from './typeInfoProvider'
+import { TypeInfoRequest, TypeInfoRequestResponse } from '../events'
+import { Provider } from './provider'
+
+@injectable()
+export class CachedTypeInfoProvider implements Provider {
+  constructor(private readonly typeInfoProvider: TypeInfoProvider) {}
+
+  async listen(client: LanguageClient): Promise<void> {
+    await client.onReady()
+    client.onRequest(TypeInfoRequest, this.onTypeInfoRequest.bind(this))
+  }
+
+  private async onTypeInfoRequest({ uris }: TypeInfoRequest): Promise<TypeInfoRequestResponse> {
+    throw new Error('method not implemented.')
+  }
+}

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -118,12 +118,12 @@ export class CachedTypeInfoProvider implements Provider {
   }
 
   private async getChecksums(files: string[]): Promise<string[]> {
-    return [...files.sort().map(md5sum)]
+    return [...files.map((uri) => vscode.Uri.parse(uri).fsPath).map(md5sum)]
   }
 
   private async updateCache(cachePath: string, files: string[], data: any, requestId: string) {
     try {
-      const checksums = await this.getChecksums(files.map((uri) => vscode.Uri.parse(uri).fsPath))
+      const checksums = await this.getChecksums(files)
 
       const cache: Cache = {
         checksums,

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -13,6 +13,8 @@ import _ from 'lodash'
 import dayjs from 'dayjs'
 import { v4 as uuid } from 'uuid'
 import * as vscode from 'vscode'
+import * as os from 'os'
+import * as cp from 'child_process'
 
 interface Cache {
   createdBy: string
@@ -37,6 +39,23 @@ export class CachedTypeInfoProvider implements Provider {
     mkdirSync(this.dllCacheDirectory, { recursive: true })
 
     vscode.commands.registerCommand('rwxml:cache:clear', this.clearCache.bind(this))
+    vscode.commands.registerCommand('rwxml:cache:openDir', this.openCacheDir.bind(this))
+  }
+
+  private openCacheDir() {
+    const platform = os.platform()
+    switch (platform) {
+      case 'win32':
+        cp.execSync(`start ${this.dllCacheDirectory}`, { shell: 'cmd.exe' })
+        return
+
+      case 'darwin':
+        cp.execSync(`open ${this.dllCacheDirectory}`)
+        return
+
+      default:
+        throw new Error(`platform ${platform} not supported. Please make an issue on github.`)
+    }
   }
 
   private async clearCache() {

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -85,6 +85,8 @@ export class CachedTypeInfoProvider implements Provider {
     const cacheData = await checkCacheValid()
     let data = cacheData.data
     if (!cacheData.valid) {
+      console.log(`[${requestId}] checksum invalid, updating cache.`)
+
       const res = await this.typeInfoProvider.onTypeInfoRequest({ uris })
       if (res.error) {
         return res

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -48,6 +48,8 @@ export class CachedTypeInfoProvider implements Provider {
   private async onTypeInfoRequest({ uris }: TypeInfoRequest): Promise<TypeInfoRequestResponse> {
     const requestId = uuid()
 
+    uris.sort()
+
     // get cache name based on checksum name of given uris
     // and make a short hash
     const cacheName = this.getCacheName(uris).slice(0, 12)

--- a/vsc-extension/src/resources/cachedTypeInfoProvider.ts
+++ b/vsc-extension/src/resources/cachedTypeInfoProvider.ts
@@ -35,6 +35,16 @@ export class CachedTypeInfoProvider implements Provider {
     @inject(PathStore.token) private readonly pathStore: PathStore
   ) {
     mkdirSync(this.dllCacheDirectory, { recursive: true })
+
+    vscode.commands.registerCommand('rwxml:cache:clear', this.clearCache.bind(this))
+  }
+
+  private async clearCache() {
+    const caches = await fs.readdir(this.dllCacheDirectory)
+    console.log(`deleting ${caches.length} caches: ${JSON.stringify(caches, null, 4)}`)
+    await Promise.all(caches.map((c) => fs.rm(path.join(this.dllCacheDirectory, c))))
+
+    vscode.window.showInformationMessage(`RWXML: Cleared ${caches.length} caches.`, 'OK')
   }
 
   async listen(client: LanguageClient): Promise<void> {

--- a/vsc-extension/src/resources/pathStore.ts
+++ b/vsc-extension/src/resources/pathStore.ts
@@ -16,7 +16,7 @@ import { singleton } from 'tsyringe'
           return c.resolve(DarwinPathStore)
 
         default:
-          throw new Error(`platform ${os.platform()} is not supported.`)
+          throw new Error(`platform ${os.platform()} is not supported.  please make an issue on github.`)
       }
     },
   },
@@ -34,7 +34,7 @@ export abstract class PathStore {
 @singleton()
 class Win32PathStore extends PathStore {
   protected defaultCacheDirectory(): string {
-    const p = 'Library\\Application Support\\rwxml-language-server\\cache'
+    const p = 'Appdata\\Roaming\\rwxml-language-server\\cache'
     return path.join(os.homedir(), p)
   }
 }

--- a/vsc-extension/src/resources/pathStore.ts
+++ b/vsc-extension/src/resources/pathStore.ts
@@ -2,6 +2,7 @@ import * as tsyringe from 'tsyringe'
 import * as vscode from 'vscode'
 import * as os from 'os'
 import * as path from 'path'
+import * as fs from 'fs'
 import { singleton } from 'tsyringe'
 
 @tsyringe.registry([
@@ -25,6 +26,10 @@ export abstract class PathStore {
   static readonly token = Symbol(PathStore.name)
 
   protected abstract defaultCacheDirectory(): string
+
+  constructor() {
+    fs.mkdirSync(this.cacheDirectory, { recursive: true })
+  }
 
   get cacheDirectory(): string {
     return vscode.workspace.getConfiguration('rwxml.extractor.cache').get<string>('paths', this.defaultCacheDirectory())

--- a/vsc-extension/src/resources/pathStore.ts
+++ b/vsc-extension/src/resources/pathStore.ts
@@ -1,0 +1,48 @@
+import * as tsyringe from 'tsyringe'
+import * as vscode from 'vscode'
+import * as os from 'os'
+import * as path from 'path'
+import { singleton } from 'tsyringe'
+
+@tsyringe.registry([
+  {
+    token: PathStore.token,
+    useFactory: (c) => {
+      switch (os.platform()) {
+        case 'win32':
+          return c.resolve(Win32PathStore)
+
+        case 'darwin':
+          return c.resolve(DarwinPathStore)
+
+        default:
+          throw new Error(`platform ${os.platform()} is not supported.`)
+      }
+    },
+  },
+])
+export abstract class PathStore {
+  static readonly token = Symbol(PathStore.name)
+
+  protected abstract defaultCacheDirectory(): string
+
+  get cacheDirectory(): string {
+    return vscode.workspace.getConfiguration('rwxml.extractor.cache').get<string>('paths', this.defaultCacheDirectory())
+  }
+}
+
+@singleton()
+class Win32PathStore extends PathStore {
+  protected defaultCacheDirectory(): string {
+    const p = 'Library\\Application Support\\rwxml-language-server\\cache'
+    return path.join(os.homedir(), p)
+  }
+}
+
+@singleton()
+class DarwinPathStore extends PathStore {
+  protected defaultCacheDirectory(): string {
+    const p = 'Library/Application Support/rwxml-language-server/cache'
+    return path.join(os.homedir(), p)
+  }
+}

--- a/vsc-extension/src/resources/provider.ts
+++ b/vsc-extension/src/resources/provider.ts
@@ -1,15 +1,16 @@
 import { registry } from 'tsyringe'
 import { LanguageClient } from 'vscode-languageclient'
+import { CachedTypeInfoProvider } from './cachedTypeInfoProvider'
 import { DependencyResourceProvider } from './dependencyResourceProvider'
 import { ResourceExistsProvider } from './resourceExistsProvider'
 import { TextProvider } from './textProvider'
-import { TypeInfoProvider } from './typeInfoProvider'
 
 @registry([
   { token: Provider.token, useClass: TextProvider },
-  { token: Provider.token, useClass: TypeInfoProvider },
   { token: Provider.token, useClass: DependencyResourceProvider },
   { token: Provider.token, useClass: ResourceExistsProvider },
+  { token: Provider.token, useClass: CachedTypeInfoProvider },
+  // { token: Provider.token, useClass: TypeInfoProvider },
 ])
 export abstract class Provider {
   static readonly token = Symbol('ProviderSymbol')

--- a/vsc-extension/src/resources/typeInfoProvider.ts
+++ b/vsc-extension/src/resources/typeInfoProvider.ts
@@ -16,7 +16,7 @@ export class TypeInfoProvider implements Provider {
   private requestCounter = 0
   private clearProgress: (() => void) | null = null
 
-  private async onTypeInfoRequest({ uris }: TypeInfoRequest): Promise<TypeInfoRequestResponse> {
+  async onTypeInfoRequest({ uris }: TypeInfoRequest): Promise<TypeInfoRequestResponse> {
     const res: TypeInfoRequestResponse = {}
     const fsPaths = uris.map((uri) => vscode.Uri.parse(uri).fsPath)
 

--- a/vsc-extension/src/typeInfo/extract.ts
+++ b/vsc-extension/src/typeInfo/extract.ts
@@ -50,8 +50,8 @@ function initExtractorProcess(dllPaths: string[], options?: { port: number }) {
   p.stdout?.setEncoding('utf-8')
   p.stderr?.setEncoding('utf-8')
 
-  p.stdout?.on('data', console.log)
-  p.stderr?.on('data', console.error)
+  // p.stdout?.on('data', console.log)
+  // p.stderr?.on('data', console.error)
 
   return p
 }

--- a/vsc-extension/src/utils/hash.ts
+++ b/vsc-extension/src/utils/hash.ts
@@ -3,11 +3,12 @@ import * as crypto from 'crypto'
 
 /**
  * creates md5checksum from given file
- * don't pass a large file because it's sync operation.
+ * 1. don't pass uri. pass fsPath
+ * 2. don't pass a large file because it's sync operation.
  */
 export function md5sum(fsPath: string) {
   const file = fs.readFileSync(fsPath)
   const checksum = crypto.createHash('md5')
   checksum.update(file)
-  return checksum.digest()
+  return checksum.digest('hex')
 }

--- a/vsc-extension/src/utils/hash.ts
+++ b/vsc-extension/src/utils/hash.ts
@@ -1,0 +1,13 @@
+import * as fs from 'fs'
+import * as crypto from 'crypto'
+
+/**
+ * creates md5checksum from given file
+ * don't pass a large file because it's sync operation.
+ */
+export function md5sum(fsPath: string) {
+  const file = fs.readFileSync(fsPath)
+  const checksum = crypto.createHash('md5')
+  checksum.update(file)
+  return checksum.digest()
+}


### PR DESCRIPTION
- DLL extracted data is now cached.
- - win32: `%APPDATA%\\rwxml-language-server\\cache\\dlls\\<md5_checksum>.json`
- - darwin: `~/Library/Application Support/rwxml-language-server/cache/dlls/<md5_checksum>.json`
- add command `RWXML: Clear DLL Cache`
- add command `RWXML: Open Cache Directory`