### PR TITLE
fix: memory leak

### DIFF
--- a/language-server/src/clientFileEventListener.ts
+++ b/language-server/src/clientFileEventListener.ts
@@ -19,7 +19,7 @@ export class ClientFileEventListener {
     private readonly fileStore: FileStore,
     @tsyringe.inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     connection.onNotification(ProjectFileAdded, ({ uri }) => this.onFileAdded(uri))
     connection.onNotification(ProjectFileChanged, ({ uri }) => this.onFileChanged(uri))

--- a/language-server/src/defManager.ts
+++ b/language-server/src/defManager.ts
@@ -31,7 +31,7 @@ export class DefManager {
     baseLogger: winston.Logger,
     public readonly version?: RimWorldVersion
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     const defType = typeInfoMap.getTypeInfoByName('Def')
     if (!defType) {

--- a/language-server/src/features/commands/defListRequestHandler.ts
+++ b/language-server/src/features/commands/defListRequestHandler.ts
@@ -21,7 +21,7 @@ export class DefListRequestHandler implements Provider {
     private readonly projectHelper: ProjectHelper,
     @tsyringe.inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   init(connection: Connection): void {

--- a/language-server/src/features/commands/parsedTypeInfoRequest.ts
+++ b/language-server/src/features/commands/parsedTypeInfoRequest.ts
@@ -20,7 +20,7 @@ export class ParsedTypeInfoRequestHandler implements Provider {
     private readonly projectHelper: ProjectHelper,
     @tsyringe.inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   init(connection: Connection): void {

--- a/language-server/src/features/decorate.ts
+++ b/language-server/src/features/decorate.ts
@@ -25,7 +25,7 @@ export class DecoProvider implements Provider {
     private readonly defProvider: Definition,
     @tsyringe.inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   init(connection: Connection): void {

--- a/language-server/src/features/diagnostics/duplicatedNode.ts
+++ b/language-server/src/features/diagnostics/duplicatedNode.ts
@@ -18,7 +18,7 @@ export class DuplicatedNode implements DiagnosticsContributor {
   private readonly log: winston.Logger
 
   constructor(private readonly rangeConverter: RangeConverter, @tsyringe.inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   getDiagnostics(project: Project, document: Document): { uri: string; diagnostics: ls.Diagnostic[] } {

--- a/language-server/src/features/diagnostics/primitive.ts
+++ b/language-server/src/features/diagnostics/primitive.ts
@@ -19,7 +19,7 @@ export class PrimitiveValue implements DiagnosticsContributor {
   private readonly log: winston.Logger
 
   constructor(private readonly rangeConverter: RangeConverter, @tsyringe.inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   getDiagnostics(_: Project, document: Document): { uri: string; diagnostics: ls.Diagnostic[] } {

--- a/language-server/src/features/diagnostics/provider.ts
+++ b/language-server/src/features/diagnostics/provider.ts
@@ -37,7 +37,7 @@ export class DiagnosticsProvider implements Provider {
     @tsyringe.injectAll(DiagnosticsContributor.token) private readonly contributors: DiagnosticsContributor[],
     @tsyringe.inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     projectManager.events.on('onProjectInitialized', this.onProjectInitialized.bind(this))
     configuration.events.on('onConfigurationChanged', this.onConfigurationChanged.bind(this))

--- a/language-server/src/features/diagnostics/reference.ts
+++ b/language-server/src/features/diagnostics/reference.ts
@@ -20,7 +20,7 @@ export class Reference implements DiagnosticsContributor {
     private readonly definition: Definition,
     @tsyringe.inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   getDiagnostics(project: Project, document: DocumentWithNodeMap): { uri: string; diagnostics: ls.Diagnostic[] } {

--- a/language-server/src/features/hover/def.ts
+++ b/language-server/src/features/hover/def.ts
@@ -12,7 +12,7 @@ export class DefHoverProvider {
   private readonly log: winston.Logger
 
   constructor(@tsyringe.inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   onDefHover(node: Def, offset: number): ls.Hover | null {

--- a/language-server/src/features/hover/hover.ts
+++ b/language-server/src/features/hover/hover.ts
@@ -69,7 +69,7 @@ export class HoverProvider implements Provider {
     private readonly projectHelper: ProjectHelper,
     @inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   protected getLogger(): winston.Logger {

--- a/language-server/src/features/hover/tag.ts
+++ b/language-server/src/features/hover/tag.ts
@@ -12,7 +12,7 @@ export class TagHoverProvider {
   private readonly log: winston.Logger
 
   constructor(@tsyringe.inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   onTagHover(node: Injectable, offset: number): ls.Hover | null {

--- a/language-server/src/fileStore.ts
+++ b/language-server/src/fileStore.ts
@@ -22,7 +22,7 @@ export class FileStore {
   private readonly referenceCounter: DefaultDictionary<string, number> = new DefaultDictionary(() => 0)
 
   constructor(@inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   get(uri: string) {

--- a/language-server/src/fs/reader.ts
+++ b/language-server/src/fs/reader.ts
@@ -15,7 +15,7 @@ export class TextReader {
     @inject(ConnectionToken) private readonly connection: Connection,
     @inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   async read(file: File): Promise<string> {

--- a/language-server/src/log.ts
+++ b/language-server/src/log.ts
@@ -5,6 +5,7 @@ export const LogToken = Symbol('LogToken')
 
 export function initializeLogger(level: string) {
   const log = winston.createLogger({
+    // transports: [],
     transports: [new winston.transports.Console({ level })],
     format: winston.format.printf((info) => `[${info.level}] ${info.message}`),
   })

--- a/language-server/src/mod/about.ts
+++ b/language-server/src/mod/about.ts
@@ -74,7 +74,7 @@ export class About {
   }
 
   constructor(@inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   updateAboutXML(text: string) {

--- a/language-server/src/mod/aboutMetadata.ts
+++ b/language-server/src/mod/aboutMetadata.ts
@@ -80,7 +80,7 @@ export class AboutMetadata {
     @tsyringe.inject(tsyringe.delay(() => About)) private readonly about: About,
     private readonly fileStore: FileStore
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     about.event.on('aboutChanged', (about) => this.onAboutChanged(about))
     notiEventManager.preEvent.on('fileAdded', (file) => this.onFileChanged(file))

--- a/language-server/src/mod/loadfolders.ts
+++ b/language-server/src/mod/loadfolders.ts
@@ -53,7 +53,7 @@ export class LoadFolder {
     notiEventManager: NotificationEventManager,
     private readonly about: About
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     about.event.on('aboutChanged', (about) => this.onAboutChanged(about))
     notiEventManager.preEvent.on('fileAdded', (file) => this.onFileChanged(file))

--- a/language-server/src/mod/modDependencyBags.ts
+++ b/language-server/src/mod/modDependencyBags.ts
@@ -186,7 +186,7 @@ export class ModDependencyBags {
     @tsyringe.inject(ConnectionToken) private readonly connection: Connection,
     @tsyringe.inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     about.event.on('aboutChanged', this.onAboutChanged.bind(this))
     aboutMetadata.event.on('aboutMetadataChanged', this.onAboutMetadataChanged.bind(this))

--- a/language-server/src/notificationEventManager.ts
+++ b/language-server/src/notificationEventManager.ts
@@ -31,7 +31,7 @@ export class NotificationEventManager {
   readonly postEvent = new EventEmitter() as TypedEventEmitter<NotificationEvents>
 
   constructor(@tsyringe.inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   listen(event: TypedEventEmitter<NotificationEvents>): void {

--- a/language-server/src/project.ts
+++ b/language-server/src/project.ts
@@ -58,7 +58,7 @@ export class Project {
     private readonly typeInfoMapProvider: TypeInfoMapProvider,
     @inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     this.defManager = new DefManager(new DefDatabase(), new NameDatabase(), new TypeInfoMap(), this.log, this.version)
 

--- a/language-server/src/project.ts
+++ b/language-server/src/project.ts
@@ -128,6 +128,10 @@ export class Project {
     }
 
     cancelTokenSource.dispose()
+    if (global.gc) {
+      this.log.debug('trigger gc (project reloaded)')
+      global.gc()
+    }
     this.isReloading = false
   }, this.reloadDebounceTimeout)
 

--- a/language-server/src/projectManager.ts
+++ b/language-server/src/projectManager.ts
@@ -34,7 +34,7 @@ export class ProjectManager {
   public readonly events = new EventEmitter() as TypedEventEmitter<Events>
 
   constructor(about: About, @inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
     about.event.on('aboutChanged', this.onAboutChanged.bind(this))
   }
 

--- a/language-server/src/resourceStore.ts
+++ b/language-server/src/resourceStore.ts
@@ -61,7 +61,7 @@ export class ResourceStore {
     private readonly modDependencyBags: ModDependencyBags,
     @inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     modDependencyBags.event.on('dependencyChanged', () => this.onDependencyChanged())
     loadFolder.event.on('loadFolderChanged', (loadFolder) => this.onLoadFolderChanged(loadFolder))

--- a/language-server/src/textDocumentManager.ts
+++ b/language-server/src/textDocumentManager.ts
@@ -20,7 +20,7 @@ export class TextDocumentManager {
   private documents: Map<string, TextDocument> = new Map()
 
   constructor(@inject(LogToken) baseLogger: winston.Logger) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   listen(events: TypedEventEmitter<NotificationEvents>) {

--- a/language-server/src/textDocumentsAdapter.ts
+++ b/language-server/src/textDocumentsAdapter.ts
@@ -34,7 +34,7 @@ export class TextDocumentsAdapter {
     @inject(ConnectionToken) private readonly connection: Connection,
     @inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
 
     this.textDocuments.listen(connection)
 

--- a/language-server/src/typeInfoMapProvider.ts
+++ b/language-server/src/typeInfoMapProvider.ts
@@ -23,7 +23,7 @@ export class TypeInfoMapProvider {
     @inject(delay(() => Project)) private readonly project: Project,
     @inject(LogToken) baseLogger: winston.Logger
   ) {
-    this.log = winston.createLogger({ transports: baseLogger.transports, format: this.logFormat })
+    this.log = baseLogger.child({ format: this.logFormat })
   }
 
   async get(requestId: string = uuid()): Promise<[TypeInfoMap, Error?]> {

--- a/vsc-extension/src/index.ts
+++ b/vsc-extension/src/index.ts
@@ -114,7 +114,7 @@ async function createServer() {
       module,
       transport: TransportKind.ipc,
       options: {
-        execArgv: ['--nolazy', '--inspect=6009', '--expose-gc'],
+        execArgv: ['--nolazy', '--inspect=6009', '--expose-gc', '--max-old-space-size=8192'],
       },
     },
   }


### PR DESCRIPTION
copying winston logger's transports causes memory leak.

https://github.com/winstonjs/winston/issues/239
https://github.com/winstonjs/winston/issues/1445
https://stackoverflow.com/questions/57151235/why-are-strings-passed-to-winston-kept-in-memory-leaking-and-ultimately-crashin
https://github.com/winstonjs/winston/issues/1871
